### PR TITLE
Allow flux controller to authenticate to Google GAR via GCP Workload Identity instead of cronjob

### DIFF
--- a/clusters/home/flux-system/_patches/gar-workload-identity.yaml
+++ b/clusters/home/flux-system/_patches/gar-workload-identity.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  annotations:
+    iam.gke.io/gcp-service-account: flux-gar-authenticator@ringed-prism-416405.iam.gserviceaccount.com  

--- a/clusters/home/flux-system/kustomization.yaml
+++ b/clusters/home/flux-system/kustomization.yaml
@@ -4,3 +4,12 @@ resources:
 - gotk-components.yaml
 - gotk-sync.yaml
 - cluster-vars.yaml
+patches:
+  - target:
+      kind: ServiceAccount
+      name: "(source-controller|image-reflector-controller)"
+    path: _patches/gar-workload-identity.yaml
+  - target:
+      kind: ServiceAccount
+      name: "kustomize-controller"
+    path: _patches/gar-workload-identity.yaml


### PR DESCRIPTION
Allow flux controller to authenticate to Google GAR via GCP Workload Identity instead of cronjob